### PR TITLE
Use keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,36 @@ Provides fundamental outcome handling with minimal overhead.
 
 I just wanted a Result library with an API I find *natural*.
 
-## Installation
+## 🚀 Key features
+
+### ✅ Fluent workflow with nice API
+```php
+$result = ok(5)
+    ->map(fn($x) => $x * 2)        // Ok(10)
+    ->map(fn($x) => $x + 1);       // Ok(11)
+```
+
+### 🧩 `use` Gleam keyword for PHP
+
+Elegant destructuring and dependency injection:
+
+```php
+$cat_result = ok(['name' => 'Luna', 'age' => 7])
+    // Bind `name` to the returned value of the callable
+    ->use('name', fn($data) =>
+        isset($data['name']) ? ok($data['name']) : err('Missing name'))
+    // Bind `age` to the returned value of the callable. `name` is accessible here.
+    ->use('age', fn($data, $name) =>
+        isset($data['age']) ? ok($data['age']) : err('Missing age'))
+    // And mapWith the previous `use` extracted fields!
+    ->mapWith(fn($data, $name, $age) =>
+        new Cat(name: $name, age: $age));
+```
+
+### ⚡️ Zero-dependency
+Pure PHP with no external runtime dependencies. Lightweight, easy to read, easy to debug.
+
+## 📦 Installation
 
 ```bash
 composer require hopr/result
@@ -16,31 +45,44 @@ composer require hopr/result
 
 See `examples/` for more examples.
 
+### Create results
+
 ```php
 use function Hopr\Result\{ok, err};
 
-// Create results
+// You can also use Ok::of(42);
 $success = ok(42);
+// You can also use Error::of("...");
 $failure = err("something went wrong");
+```
 
-// Chain operations
+### Chain transformations
+```php
 $result = ok(5)
     ->map(fn($x) => $x * 2)        // Ok(10)
     ->map(fn($x) => $x + 1);       // Ok(11)
+```
 
-// Handle errors gracefully
+#### Graceful error handling
+```php
 $result = err("bad input")
-    ->map(fn($x) => $x * 2)        // Error("bad input")
-    ->mapErr(fn($e) => "Error: $e"); // Error("Error: bad input")
+    ->map(fn($x) => $x * 2)           // Still err("bad input")
+    ->mapErr(fn($e) => "Error: $e");  // err("Error: bad input")
+```
 
-// Safe unwrapping
+### Safe unwrapping
+
+```php
 if ($result->isOk()) {
-    $value = $result->unwrap();     // Get value safely
+    $value = $result->unwrap();       // ✅ safe
 } else {
-    $value = $result->unwrapOr(0);  // Use default value
+    $value = $result->unwrapOr(0);    // fallback value
 }
+```
 
-// Monadic binding
+### Monadic binding
+
+```php
 $parseNumber = function(string $input) {
     return is_numeric($input) 
         ? ok((int)$input)
@@ -49,7 +91,6 @@ $parseNumber = function(string $input) {
 
 $result = ok("42")->bind($parseNumber);  // Ok(42)
 ```
-
 For more examples, check the interface documentation in `src/Result.php`.
 
 # The Hopr project

--- a/mago.toml
+++ b/mago.toml
@@ -1,0 +1,17 @@
+# Mago configuration file
+# For more information, see https://mago.carthage.software/#/getting-started/configuration
+php_version = "8.4.0"
+
+[source]
+paths = ["src/"]
+includes = ["vendor"]
+excludes = []
+
+[format]
+print_width = 120
+tab_width = 4
+use_tabs = false
+
+[linter]
+default_plugins = true
+plugins = ["safety", "consistency","analysis"]

--- a/src/Error.php
+++ b/src/Error.php
@@ -147,7 +147,7 @@ class Error implements Result
     #[\Override]
     public function __toString(): string
     {
-        return sprintf('Error(%s)', $this->error);
+        return sprintf('Error(%s)', var_export($this->error));
     }
 
     #[\Override]
@@ -161,10 +161,10 @@ class Error implements Result
      *
      * @template U
      * @param callable(mixed ...$args): U $fn
-     * @return self
+     * @return Result<T, E>
      */
     #[\Override]
-    public function mapWith(callable $fn): self
+    public function mapWith(callable $fn): Result
     {
         return $this;
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hopr\Result;
 
 /**
@@ -23,7 +25,7 @@ class Error implements Result
      *
      * @param E $error The error value
      */
-    private function __construct($error)
+    private function __construct(mixed $error)
     {
         $this->error = $error;
     }
@@ -35,7 +37,7 @@ class Error implements Result
      * @param F $error The error value
      * @return Error<mixed, F> A new Error instance
      */
-    public static function of($error): Error
+    public static function of(mixed $error): Error
     {
         return new self($error);
     }
@@ -47,6 +49,7 @@ class Error implements Result
      * @param callable(T): U $fn
      * @return Error<U, E>
      */
+    #[\Override]
     public function map(callable $fn): Result
     {
         // No success value to map, so return unchanged
@@ -60,6 +63,7 @@ class Error implements Result
      * @param callable(T): Result<U, E> $fn
      * @return Error<U, E>
      */
+    #[\Override]
     public function bind(callable $fn): Result
     {
         // No success value to bind, so return unchanged
@@ -73,6 +77,7 @@ class Error implements Result
      * @param callable(E): F $fn
      * @return Error<T, F>
      */
+    #[\Override]
     public function mapErr(callable $fn): Result
     {
         return new self($fn($this->error));
@@ -81,6 +86,7 @@ class Error implements Result
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function isOk(): bool
     {
         return false;
@@ -89,6 +95,7 @@ class Error implements Result
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function isErr(): bool
     {
         return true;
@@ -100,9 +107,12 @@ class Error implements Result
      * @return T
      * @throws \RuntimeException
      */
-    public function unwrap()
+    #[\Override]
+    public function unwrap(): string
     {
-        $message = is_string($this->error) ? $this->error : 'Error value encountered in unwrap(). You should check if the Result is ok with isOk() before calling unwrap().';
+        $message = is_string($this->error)
+            ? $this->error
+            : 'Error value encountered in unwrap(). You should check if the Result is ok with isOk() before calling unwrap().';
         throw new \RuntimeException($message);
     }
 
@@ -113,7 +123,8 @@ class Error implements Result
      * @param D $default
      * @return D The default value
      */
-    public function unwrapOr($default)
+    #[\Override]
+    public function unwrapOr($default): mixed
     {
         return $default;
     }
@@ -123,7 +134,7 @@ class Error implements Result
      *
      * @return E The error value
      */
-    public function getError()
+    public function getError(): mixed
     {
         return $this->error;
     }
@@ -133,8 +144,28 @@ class Error implements Result
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
         return sprintf('Error(%s)', $this->error);
+    }
+
+    #[\Override]
+    public function use(string $field, callable $fn): self
+    {
+        return $this;
+    }
+
+    /**
+     * Do nothing, return self
+     *
+     * @template U
+     * @param callable(mixed ...$args): U $fn
+     * @return self
+     */
+    #[\Override]
+    public function mapWith(callable $fn): self
+    {
+        return $this;
     }
 }

--- a/src/Error.php
+++ b/src/Error.php
@@ -168,4 +168,14 @@ class Error implements Result
     {
         return $this;
     }
+
+    /**
+     * Doesn't do anything for error
+     * @param callable(T $value): void $fn The function to execute, that doesn't modify the inner value
+     * @return Result<T, E>
+     */
+    public function tap(callable $fn): Result
+    {
+        return $this;
+    }
 }

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -177,4 +177,14 @@ class Ok implements Result
     {
         return sprintf('Ok(%s)', var_export($this->value, true));
     }
+
+    /**
+     * @param callable(T $value): void $fn The function to execute, that doesn't modify the inner value
+     * @return Result<T, E>
+     */
+    public function tap(callable $fn): Result
+    {
+        $fn($this->value);
+        return $this;
+    }
 }

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -79,7 +79,8 @@ class Ok implements Result
      * Chains a function that extracts a value from the current value/context.
      * The function must return an Ok with a named array of new context values.
      *
-     * @param callable(mixed ...$args): Result<array<string, mixed>, E> $fn
+     * @param string $field Name under which the value is stored
+     * @param callable(mixed ...$args): Result<mixed, E> $fn Callback producing the new value
      * @return Result<T, E>
      */
     #[\Override]

--- a/src/Ok.php
+++ b/src/Ok.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Hopr\Result;
 
 /**
@@ -19,13 +21,20 @@ class Ok implements Result
     private $value;
 
     /**
+     * @var array<string, mixed> Contextual values accumulated via `use`
+     */
+    private array $context = [];
+
+    /**
      * Ok constructor
      *
      * @param T $value The success value
+     * @param array<string, mixed> $context Optional context
      */
-    private function __construct($value)
+    private function __construct(mixed $value, array $context = [])
     {
         $this->value = $value;
+        $this->context = $context;
     }
 
     /**
@@ -35,7 +44,7 @@ class Ok implements Result
      * @param U $value The success value
      * @return Ok<U, mixed> A new Ok instance
      */
-    public static function of($value): Ok
+    public static function of(mixed $value): Ok
     {
         return new self($value);
     }
@@ -47,9 +56,10 @@ class Ok implements Result
      * @param callable(T): U $fn
      * @return Ok<U, E>
      */
+    #[\Override]
     public function map(callable $fn): Result
     {
-        return new self($fn($this->value));
+        return new self($fn($this->value), $this->context);
     }
 
     /**
@@ -59,9 +69,46 @@ class Ok implements Result
      * @param callable(T): Result<U, E> $fn
      * @return Result<U, E>
      */
+    #[\Override]
     public function bind(callable $fn): Result
     {
         return $fn($this->value);
+    }
+
+    /**
+     * Chains a function that extracts a value from the current value/context.
+     * The function must return an Ok with a named array of new context values.
+     *
+     * @param callable(mixed ...$args): Result<array<string, mixed>, E> $fn
+     * @return Result<T, E>
+     */
+    #[\Override]
+    public function use(string $field, callable $fn): Result
+    {
+        $result = $fn($this->value, ...array_values($this->context));
+
+        if ($result instanceof Error) {
+            return $result;
+        }
+
+        $newContext = $this->context;
+        $newContext[$field] = $result->unwrap();
+
+        return new self($this->value, $newContext);
+    }
+
+    /**
+     * Redefines the main value using the current context and initial value.
+     *
+     * @template U
+     * @param callable(mixed ...$args): U $fn
+     * @return Ok<U, E>
+     */
+    #[\Override]
+    public function mapWith(callable $fn): Result
+    {
+        $args = [$this->value, ...array_values($this->context)];
+        return new self($fn(...$args), $this->context);
     }
 
     /**
@@ -71,15 +118,16 @@ class Ok implements Result
      * @param callable(E): F $fn
      * @return Ok<T, F>
      */
+    #[\Override]
     public function mapErr(callable $fn): Result
     {
-        // No error to map, so return unchanged
         return $this;
     }
 
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function isOk(): bool
     {
         return true;
@@ -88,6 +136,7 @@ class Ok implements Result
     /**
      * {@inheritdoc}
      */
+    #[\Override]
     public function isErr(): bool
     {
         return false;
@@ -98,7 +147,8 @@ class Ok implements Result
      *
      * @return T
      */
-    public function unwrap()
+    #[\Override]
+    public function unwrap(): mixed
     {
         return $this->value;
     }
@@ -108,9 +158,10 @@ class Ok implements Result
      *
      * @template D
      * @param D $default
-     * @return T The success value (default is ignored)
+     * @return T
      */
-    public function unwrapOr($default)
+    #[\Override]
+    public function unwrapOr($default): mixed
     {
         return $this->value;
     }
@@ -120,8 +171,9 @@ class Ok implements Result
      *
      * @return string
      */
+    #[\Override]
     public function __toString(): string
     {
-        return sprintf('Ok(%s)', $this->value);
+        return sprintf('Ok(%s)', var_export($this->value, true));
     }
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -153,4 +153,10 @@ interface Result
      * @return Ok<U, E>
      */
     public function mapWith(callable $fn): Result;
+
+    /**
+     * @param callable(T $value): void $fn The function to execute, that doesn't modify the inner value
+     * @return Result<T, E>
+     */
+    public function tap(callable $fn): Result;
 }

--- a/src/Result.php
+++ b/src/Result.php
@@ -134,4 +134,23 @@ interface Result
      * ```
      */
     public function unwrapOr($default);
+
+    /**
+     * Accumulates contextual data or propagates an Error.
+     *
+     * @param string $field  Key under which the produced value is stored.
+     * @param callable $fn Receives the current success value *plus* any previously accumulated context values and returns a Result.
+     *
+     * @return Result<T, E>
+     */
+    public function use(string $field, callable $fn): Result;
+
+    /**
+     * Redefines the main value using the current context and initial value.
+     *
+     * @template U
+     * @param callable(mixed ...$args): U $fn
+     * @return Ok<U, E>
+     */
+    public function mapWith(callable $fn): Result;
 }

--- a/tests/Unit/useTest.php
+++ b/tests/Unit/useTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use function Hopr\Result\err;
+use function Hopr\Result\ok;
+
+test('use transmet bien les champs indiqués', function () {
+    $cat_result = ok(['name' => 'Luna', 'age' => 7])
+        // Bind `name` to the returned value of the callable
+        ->use('name', fn($data) => isset($data['name']) ? ok($data['name']) : err('Missing name'))
+        // Bind `age` to the returned value of the callable. `name` is accessible here.
+        ->use('age', fn($data, $name) => isset($data['age']) ? ok($data['age']) : err('Missing age'))
+        // And mapWith the previous `use` extracted fields !
+        ->mapWith(fn($data, $name, $age) => [
+            $name,
+            $age,
+        ]);
+
+    expect($cat_result->unwrapOr(null))->toBe(['Luna', 7]);
+});


### PR DESCRIPTION
Like in gleam, a use Keyword to use like this.
```php
$a = ok(['name' => 'Cédric', 'age' => 30])
    ->use('name', fn($data) =>
        isset($data['name']) ? ok($data['name']) : err('Missing name'))
    ->use('age', fn($data, $name) =>
        isset($data['age']) ? ok($data['age']) : err('Missing age'))
    ->mapWith(fn($data, $name, $age) =>
        new User($name, $age));

var_dump($a->unwrap());

$a = ok(43)
    ->use('lessTen', fn(int $data) =>
    $data < 10 ? ok(true) : ok(false))
    ->use('lessFive', fn($data, $_) =>
    $data < 5 ? ok(true) : ok(false))
    ->mapWith(fn($data, $lessTen, $lessFive) =>
        [$data, $lessTen, $lessFive]);

var_dump($a);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced context management for results, allowing additional named context values to be attached and propagated alongside main values.
  - Added new methods enabling functions to access both main values and accumulated context, and to transform values while preserving context.
  - Added a method to perform side-effect operations on result values without modification.
  - Added comprehensive usage examples and a "Key features" overview to the documentation for easier adoption.
- **Improvements**
  - Improved string representation of result values for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->